### PR TITLE
Use resetController.

### DIFF
--- a/addon/mixins/data-route.js
+++ b/addon/mixins/data-route.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  deactivate: function() {
+  resetController: function() {
     var model = this.get('controller.model');
     if(!model.get('isDeleted')) {
       model.rollback();


### PR DESCRIPTION
This ensures that a `this.get('controller.model').rollback()` occurs even when transitioning within the same route (as evidenced by the JSBin in #7 the `deactivate` hook does not fire when changing models within the same route).

Closes #7.
