### PR TITLE
feat: set the primary model

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,23 @@ argument for you to handle. One possible override could be:
 
 ```js
 export default Ember.Route.extend(DataRouteMixin, {
-  willTransitionConfirm: function() {
+  willTransitionConfirm() {
     return window.confirm("You have unsaved changes that will be lost. Do you want to continue?");
   }
 });
 ```
+
+### Configuring Which Model ###
+
+Sometimes `model` isn't the place where your primary model is located, so setting `primaryModel` to something else would allow you to override that setting.
+
+```js
+export default Ember.Route.extend(DataRouteMixin, {
+  primaryModel: 'user'
+});
+```
+
+This will look on `controller.user`, instead of `controller.model`.
 
 ## Authors ##
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -6,8 +6,10 @@ const {
 } = Ember;
 
 export default Mixin.create({
+  primaryModel: 'model',
   resetController() {
-    let model = get(this, 'controller.model');
+    let primaryModel = get(this, 'primaryModel');
+    let model = get(this, `controller.${primaryModel}`);
 
     if (!get(model, 'isDeleted')) {
       model.rollbackAttributes();
@@ -15,7 +17,8 @@ export default Mixin.create({
   },
   actions: {
     willTransition(transition) {
-      let model = get(this, 'controller.model');
+      let primaryModel = get(this, 'primaryModel');
+      let model = get(this, `controller.${primaryModel}`);
 
       if (get(model, 'hasDirtyAttributes') && !this.willTransitionConfirm(transition)) {
         transition.abort();

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0",
+    "ember-data": "2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",

--- a/tests/dummy/app/controllers/people/new.js
+++ b/tests/dummy/app/controllers/people/new.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+const { Controller } = Ember;
+
+export default Controller.extend({
+});

--- a/tests/dummy/app/routes/people/new.js
+++ b/tests/dummy/app/routes/people/new.js
@@ -1,12 +1,22 @@
 import Ember from 'ember';
 import DataRouteMixin from 'ember-data-route';
 
-const { Route } = Ember;
+const { RSVP, Route } = Ember;
 
 export default Route.extend(DataRouteMixin, {
+  primaryModel: 'person',
+
   model() {
-    return this.store.findRecord('organization', 1).then((organization) => {
-      return this.store.createRecord('person', { organization });
+    return RSVP.hash({
+      organization: this.store.findRecord('organization', 1)
     });
+  },
+
+  setupController(controller, resolved) {
+    resolved.person = this.store.createRecord('person', {
+      organization: resolved.organization
+    });
+
+    controller.setProperties(resolved);
   }
 });

--- a/tests/dummy/app/templates/people/new.hbs
+++ b/tests/dummy/app/templates/people/new.hbs
@@ -1,1 +1,3 @@
-{{partial 'people/form'}}
+{{link-to "Index" "people"}}
+
+{{input value=person.name class="name"}}


### PR DESCRIPTION
`primaryModel` defaults to `'model'` but can be changed in cases where the `model` hook must return an array or hash of promises and the user wants to be explicit about the model in the template e.g. `user` vs `model`