### PR TITLE
Update ember-cli-babel to ^6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^6.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fixes a deprecation warning: 
```
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6
```